### PR TITLE
Bug Fixes

### DIFF
--- a/addons/pointshop-master/lua/pointshop/items/playermodels/__category.lua
+++ b/addons/pointshop-master/lua/pointshop/items/playermodels/__category.lua
@@ -1,2 +1,3 @@
 CATEGORY.Name = 'Player Models'
 CATEGORY.Icon = 'user'
+CATEGORY.AllowedTeams = {2}

--- a/addons/pointshop-master/lua/pointshop/items/powerups/supersmall.lua
+++ b/addons/pointshop-master/lua/pointshop/items/powerups/supersmall.lua
@@ -5,14 +5,14 @@ ITEM.NoPreview = true
 
 function ITEM:OnEquip(ply, modifications)
 	ply:SetModelScale(.5, 0)
-	if(ply:GetUserGroup() == "Hunter") then
+	if(ply:Team() == 2) then
 		ply:SetNWFloat("modelScale", .5)
 		local offset = Vector(0, 0, 32)
 		ply:SetViewOffset(offset)
 		ply:SetViewOffsetDucked(offset)
 	end
 
-	if(ply:GetUserGroup() == "Prop") then
+	if(ply:Team() == 3) then
 		if(ply:IsDisguised()) then
 		tempEnt = ply:GetNWEntity("disguiseEntity")
 		ply:SetNWFloat("modelScale", .5)
@@ -25,14 +25,14 @@ end
 function ITEM:OnHolster(ply)
 	ply:SetModelScale(1, 1)
 
-	if(ply:GetUserGroup() == "Hunter") then
+	if(ply:Team() == 2) then
 		ply:SetNWFloat("modelScale", 1)
 		local offset = Vector(0, 0, 64)
 		ply:SetViewOffset(offset)
 		ply:SetViewOffsetDucked(offset)
 	end
 
-	if(ply:GetUserGroup() == "Prop") then
+	if(ply:Team() == 3) then
 				if(ply:IsDisguised()) then
 		tempEnt = ply:GetNWEntity("disguiseEntity")
 		ply:SetNWFloat("modelScale", 1)

--- a/addons/pointshop-master/lua/pointshop/items/weapons/__category.lua
+++ b/addons/pointshop-master/lua/pointshop/items/weapons/__category.lua
@@ -1,4 +1,4 @@
 CATEGORY.Name = 'Weapons'
 CATEGORY.Icon = 'bomb'
 CATEGORY.Order = -1
-CATEGORY.AllowedUserGroups = {"Hunter"}
+CATEGORY.AllowedTeams = {2} --2 (hunter) 3 (prop)

--- a/addons/pointshop-master/lua/pointshop/sh_init.lua
+++ b/addons/pointshop-master/lua/pointshop/sh_init.lua
@@ -70,7 +70,7 @@ function PS:LoadItems()
 			CATEGORY.Icon = ''
 			CATEGORY.Order = 0
 			CATEGORY.AllowedEquipped = -1
-			CATEGORY.AllowedUserGroups = {}
+			CATEGORY.AllowedTeams = {}
 			CATEGORY.CanPlayerSee = function() return true end
 			CATEGORY.ModifyTab = function(tab) return end
 			
@@ -97,7 +97,7 @@ function PS:LoadItems()
 					-- model and material are missing but there's no way around it, there's a check below anyway
 					
 					ITEM.AdminOnly = false
-					ITEM.AllowedUserGroups = {} -- this will fail the #ITEM.AllowedUserGroups test and continue
+					ITEM.AllowedTeams = {} -- this will fail the #ITEM.AllowedTeams test and continue
 					ITEM.SingleUse = false
 					ITEM.NoPreview = false
 					

--- a/addons/pointshop-master/lua/pointshop/sh_player_extension.lua
+++ b/addons/pointshop-master/lua/pointshop/sh_player_extension.lua
@@ -2,8 +2,8 @@ local Player = FindMetaTable('Player')
 
 -- Because of the huge variaty of admin mods and their various ways of handling usergroups.
 -- This had to be done..
-function Player:PS_GetUsergroup()
+function Player:PS_GetTeam()
 	-- add for each conflicting admin mod.
 
-	return self:GetNWString("UserGroup")
+	return self:Team()
 end

--- a/addons/pointshop-master/lua/pointshop/sv_player_extension.lua
+++ b/addons/pointshop-master/lua/pointshop/sv_player_extension.lua
@@ -199,8 +199,8 @@ function Player:PS_BuyItem(item_id)
 		return false
 	end
 
-	if ITEM.AllowedUserGroups and #ITEM.AllowedUserGroups > 0 then
-		if not table.HasValue(ITEM.AllowedUserGroups, self:PS_GetUsergroup()) then
+	if ITEM.AllowedTeams and #ITEM.AllowedTeams > 0 then
+		if not table.HasValue(ITEM.AllowedTeams, self:PS_GetTeam()) then
 			self:PS_Notify('You\'re not in the right group to buy this item!')
 			return false
 		end
@@ -209,8 +209,8 @@ function Player:PS_BuyItem(item_id)
 	local cat_name = ITEM.Category
 	local CATEGORY = PS:FindCategoryByName(cat_name)
 
-	if CATEGORY.AllowedUserGroups and #CATEGORY.AllowedUserGroups > 0 then
-		if not table.HasValue(CATEGORY.AllowedUserGroups, self:PS_GetUsergroup()) then
+	if CATEGORY.AllowedTeams and #CATEGORY.AllowedTeams > 0 then
+		if not table.HasValue(CATEGORY.AllowedTeams, self:PS_GetTeam()) then
 			self:PS_Notify('You\'re not in the right group to buy this item!')
 			return false
 		end

--- a/addons/pointshop-master/lua/pointshop/vgui/DPointShopItem.lua
+++ b/addons/pointshop-master/lua/pointshop/vgui/DPointShopItem.lua
@@ -150,7 +150,7 @@ function PANEL:PaintOver()
 		surface.DrawTexturedRect(self:GetWide() - 5 - 16, 5, 16, 16)
 	end
 	
-	if self.Data.AllowedUserGroups and #self.Data.AllowedUserGroups > 0 then
+	if self.Data.AllowedTeams and #self.Data.AllowedTeams > 0 then
 		surface.SetMaterial(groupicon)
 		surface.SetDrawColor(Color(255, 255, 255, 255))
 		surface.DrawTexturedRect(5, self:GetTall() - self.InfoHeight - 5 - 16, 16, 16)

--- a/addons/pointshop-master/lua/pointshop/vgui/DPointShopMenu.lua
+++ b/addons/pointshop-master/lua/pointshop/vgui/DPointShopMenu.lua
@@ -215,9 +215,9 @@ function PANEL:Init()
 	
 	-- items
 	for _, CATEGORY in pairs(categories) do
-		LocalPlayer():PrintMessage( HUD_PRINTCONSOLE, LocalPlayer():PS_GetUsergroup() )
-		if CATEGORY.AllowedUserGroups and #CATEGORY.AllowedUserGroups > 0 then
-			if not table.HasValue(CATEGORY.AllowedUserGroups, LocalPlayer():PS_GetUsergroup()) then
+		LocalPlayer():PrintMessage( HUD_PRINTCONSOLE, LocalPlayer():PS_GetTeam() )
+		if CATEGORY.AllowedTeams and #CATEGORY.AllowedTeams > 0 then
+			if not table.HasValue(CATEGORY.AllowedTeams, LocalPlayer():PS_GetTeam()) then
 				continue
 			end
 		end

--- a/gamemodes/prop_hunt/gamemode/sv_rounds.lua
+++ b/gamemodes/prop_hunt/gamemode/sv_rounds.lua
@@ -320,37 +320,18 @@ end
 
 function GM:RoundsThink()
 
-		for k, ply in pairs(player.GetAll()) do
-
-			if(ply:Team() == 2)then
-				ply:SetUserGroup("Hunter")
-				ply:SetNWString('UserGroup', "Hunter")
-				
-			end
-
-			if(ply:Team() == 3)then
-				ply:SetUserGroup("Prop")
-				ply:SetNWString('UserGroup', "Prop")
-			end
-		end
-
 	if self:GetGameState() == 0 then
 		local c = 0
 		for k, ply in pairs(player.GetAll()) do
 			if ply:Team() != 1 then // ignore spectators
 				c = c + 1
-				if(ply:Team() == 2)then
-					ply:SetUserGroup("Hunter")
-				end
-				if(ply:Team() == 3)then
-					ply:SetUserGroup("Prop")
-				end
 			end
 		end
 		if c >= 2 && self.RoundWaitForPlayers + self.StartWaitTime:GetFloat() < CurTime() then
 			self:SetupRound()
 		end
 	elseif self:GetGameState() == 1 then
+		--self:CheckForVictory()
 		if self:GetStateRunningTime() > 30 then
 			self:StartRound()
 		end


### PR DESCRIPTION
The item shop was using a players "UserGroup" attribute to keep track of
hunter or prop. ULX admin mod uses  UserGroup to keep track of the
players admin status. Every round it would remove ULX admin rights and set it to hunter or prop. The point shop has been rewritten to use the players team instead.

Accessing the player model menu in the point shop is now disabled for
props. Ultimately we should limit only hunters to custom models so there
is no confusion.  This would also fix issues with the hunter halos.
